### PR TITLE
Refactor code to add action that is invoked when exception occurs.

### DIFF
--- a/src/MilestoneTG.Extensions.Configuration.S3.UnitTests/MilestoneTG.Extensions.Configuration.S3.UnitTests.csproj
+++ b/src/MilestoneTG.Extensions.Configuration.S3.UnitTests/MilestoneTG.Extensions.Configuration.S3.UnitTests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="Moq" Version="4.13.1" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MilestoneTG.Extensions.Configuration.S3\MilestoneTG.Extensions.Configuration.S3.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/MilestoneTG.Extensions.Configuration.S3.UnitTests/S3ConfigurationProviderTests.cs
+++ b/src/MilestoneTG.Extensions.Configuration.S3.UnitTests/S3ConfigurationProviderTests.cs
@@ -1,0 +1,379 @@
+﻿using Amazon.S3;
+using Amazon.S3.Model;
+using Microsoft.Extensions.Primitives;
+using Moq;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace MilestoneTG.Extensions.Configuration.S3.UnitTests
+{
+    [TestFixture(Author = "Tamás Sinku (sinkutamas@gmail.com)")]
+    [TestOf(typeof(S3ConfigurationProvider))]
+    public class S3ConfigurationProviderTests
+    {
+        private const string ExpectedBucketName = "test-bucket";
+        private const string ExpectedS3Key = "test-key";
+
+        [Test(Description = "Tests that the constructor throws exception if configuration is null.")]
+        [Author("Tamás Sinku (sinkutamas@gmail.com)")]
+        public void ConstructorValidatesConfigForNullValueTest()
+        {
+            //arrange
+            IS3ProviderConfiguration config = null;
+
+            //act
+            void Invoke() => new S3ConfigurationProvider(config, null, null, null);
+
+            //assert
+            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(Invoke);
+            Assert.That(ex.ParamName, Is.EqualTo("config"));
+        }
+
+        [Test(Description = "Tests that the constructor checks if a valid S3 bucket name is provided in the configuration.")]
+        [Author("Tamás Sinku (sinkutamas@gmail.com)")]
+        public void ConstructorValidatesBucketNameProperlyTest()
+        {
+            //arrange
+            Mock<IS3ProviderConfiguration> configMock = new Mock<IS3ProviderConfiguration>(MockBehavior.Strict);
+            configMock
+                .SetupGet(x => x.BucketName)
+                .Returns((string)null)
+                .Verifiable();
+
+            //act
+            void Invoke() => new S3ConfigurationProvider(configMock.Object, null, null, null);
+
+            //assert
+            ArgumentException ex = Assert.Throws<ArgumentException>(Invoke);
+            Assert.That(ex.ParamName, Is.EqualTo("config"));
+            Assert.That(ex.Message.Contains("BucketName cannot be null."), Is.True);
+            configMock.Verify();
+        }
+
+        [Test(Description = "Tests that the constructor checks if a valid S3 key is provided in the configuration.")]
+        [Author("Tamás Sinku (sinkutamas@gmail.com)")]
+        public void ConstructorValidatesKeyProperlyTest()
+        {
+            //arrange
+            Mock<IS3ProviderConfiguration> configMock = new Mock<IS3ProviderConfiguration>(MockBehavior.Strict);
+            configMock
+                .SetupGet(x => x.BucketName)
+                .Returns(ExpectedBucketName)
+                .Verifiable();
+
+            configMock
+                .SetupGet(x => x.Key)
+                .Returns((string)null)
+                .Verifiable();
+
+            //act
+            void Invoke() => new S3ConfigurationProvider(configMock.Object, null, null, null);
+
+            //assert
+            ArgumentException ex = Assert.Throws<ArgumentException>(Invoke);
+            Assert.That(ex.ParamName, Is.EqualTo("config"));
+            Assert.That(ex.Message.Contains("Key cannot be null."), Is.True);
+            configMock.Verify();
+        }
+
+        [Test(Description = "Tests that the LoadAsync method can load configuration properly from S3 bucket.")]
+        [Author("Tamás Sinku (sinkutamas@gmail.com)")]
+        public void ConfigurationInitialLoadingTest()
+        {
+            //arrange
+            IDictionary<string, string> configFromS3 = new Dictionary<string, string>()
+            {
+                ["key1"] = "value1",
+                ["key2"] = "value2",
+            };
+
+            Mock<IS3ProviderConfiguration> configMock = new Mock<IS3ProviderConfiguration>(MockBehavior.Strict);
+            configMock
+                .SetupGet(x => x.BucketName)
+                .Returns(ExpectedBucketName)
+                .Verifiable();
+
+            configMock
+                .SetupGet(x => x.Key)
+                .Returns(ExpectedS3Key)
+                .Verifiable();
+
+            Mock<IAmazonS3> s3Mock = new Mock<IAmazonS3>(MockBehavior.Strict);
+            s3Mock
+                .Setup(x => x.GetObjectAsync(
+                    It.Is<GetObjectRequest>(input => input.BucketName == ExpectedBucketName && input.Key == ExpectedS3Key && input.EtagToNotMatch == null),
+                    It.IsAny<CancellationToken>()
+                ))
+                .ReturnsAsync(
+                    new GetObjectResponse()
+                    {
+                        BucketName = ExpectedBucketName,
+                        Key = ExpectedS3Key
+                    }
+                )
+                .Verifiable();
+
+            Mock<IS3ObjectParser> parserMock = new Mock<IS3ObjectParser>(MockBehavior.Strict);
+            parserMock
+                .Setup(x => x.ParseAsync(
+                    It.Is<GetObjectResponse>(
+                        input => input.BucketName == ExpectedBucketName && input.Key == ExpectedS3Key
+                    )
+                ))
+                .ReturnsAsync(configFromS3)
+                .Verifiable();
+
+            //act
+            S3ConfigurationProvider provider = new S3ConfigurationProvider(configMock.Object, s3Mock.Object, parserMock.Object, null);
+
+            bool reloadTriggered = false;
+            using (ChangeToken.OnChange(provider.GetReloadToken, () => reloadTriggered = true))
+            {
+                provider.Load();
+            }
+
+            //assert
+            Assert.That(reloadTriggered, Is.True);
+            configMock.Verify();
+            s3Mock.Verify();
+            parserMock.Verify();
+        }
+
+        [Test(Description = "Tests that the provider can reload configuration properly and notifies the configuration system about the change.")]
+        [Author("Tamás Sinku (sinkutamas@gmail.com)")]
+        public void ConfigurationReloadingTest()
+        {
+            //arrange
+            string initialEtag = "1";
+            IDictionary<string, string> initialConfiguration = new Dictionary<string, string>()
+            {
+                ["key1"] = "value1",
+                ["key2"] = "value2",
+            };
+
+            string newEtag = "2";
+            IDictionary<string, string> newConfiguration = new Dictionary<string, string>()
+            {
+                ["key1"] = "new-value1",
+                ["key2"] = "new-value2",
+            };
+
+            Mock<IS3ProviderConfiguration> configMock = new Mock<IS3ProviderConfiguration>(MockBehavior.Strict);
+            configMock
+                .SetupGet(x => x.BucketName)
+                .Returns(ExpectedBucketName)
+                .Verifiable();
+
+            configMock
+                .SetupGet(x => x.Key)
+                .Returns(ExpectedS3Key)
+                .Verifiable();
+            
+            Mock<IAmazonS3> s3Mock = new Mock<IAmazonS3>(MockBehavior.Strict);
+            s3Mock
+                .SetupSequence(x => x.GetObjectAsync(
+                    It.Is<GetObjectRequest>(input => input.BucketName == ExpectedBucketName && input.Key == ExpectedS3Key && input.EtagToNotMatch == null || input.EtagToNotMatch == initialEtag),
+                    It.IsAny<CancellationToken>()
+                ))
+                .ReturnsAsync(
+                    new GetObjectResponse()
+                    {
+                        BucketName = ExpectedBucketName,
+                        Key = ExpectedS3Key,
+                        ETag = initialEtag
+                    }
+                )
+                .ReturnsAsync(
+                    new GetObjectResponse()
+                    {
+                        BucketName = ExpectedBucketName,
+                        Key = ExpectedS3Key,
+                        ETag = newEtag
+                    }
+                );
+            
+            Mock<IS3ObjectParser> parserMock = new Mock<IS3ObjectParser>(MockBehavior.Strict);
+            parserMock
+                .SetupSequence(x => x.ParseAsync(
+                    It.Is<GetObjectResponse>(
+                        input => input.BucketName == ExpectedBucketName && input.Key == ExpectedS3Key
+                    )
+                ))
+                .ReturnsAsync(initialConfiguration)
+                .ReturnsAsync(newConfiguration);
+            
+            Mock<IReloadTrigger> triggerMock = new Mock<IReloadTrigger>();
+            triggerMock
+                .SetupAdd(x => x.Triggered += It.IsAny<EventHandler>())
+                .Verifiable();
+
+            //act
+            S3ConfigurationProvider provider = new S3ConfigurationProvider(configMock.Object, s3Mock.Object, parserMock.Object, triggerMock.Object);
+
+            int loadTimes = 0;
+            using (ChangeToken.OnChange(provider.GetReloadToken, () => loadTimes++))
+            {
+                provider.Load();
+                triggerMock.Raise(x => x.Triggered += null, EventArgs.Empty);
+            }
+            
+            //assert
+            foreach (var configItem in newConfiguration)
+            {
+                if (!provider.TryGet(configItem.Key, out string value))
+                    Assert.Fail($"Configuration provider was not able to retrieve the expected configuration value for key '{configItem.Key}'.");
+
+                Assert.That(value, Is.EqualTo(configItem.Value));
+            }
+
+            Assert.That(loadTimes, Is.EqualTo(2));
+            configMock.Verify();
+            s3Mock.Verify();
+            parserMock.Verify();
+            triggerMock.Verify();
+        }
+
+        [Test(Description = "Tests that the provider does not notify the configuration system during reload when the configuration has not changed.")]
+        [Author("Tamás Sinku (sinkutamas@gmail.com)")]
+        public void ConfigurationReloadingTestWithNonChangedConfig()
+        {
+            //arrange
+            string initialEtag = "1";
+            IDictionary<string, string> initialConfiguration = new Dictionary<string, string>()
+            {
+                ["key1"] = "value1",
+                ["key2"] = "value2",
+            };
+
+            Mock<IS3ProviderConfiguration> configMock = new Mock<IS3ProviderConfiguration>(MockBehavior.Strict);
+            configMock
+                .SetupGet(x => x.BucketName)
+                .Returns(ExpectedBucketName)
+                .Verifiable();
+
+            configMock
+                .SetupGet(x => x.Key)
+                .Returns(ExpectedS3Key)
+                .Verifiable();
+
+            configMock
+                .SetupGet(x => x.Optional)
+                .Returns(false)
+                .Verifiable();
+            
+            Mock<IAmazonS3> s3Mock = new Mock<IAmazonS3>(MockBehavior.Strict);
+            s3Mock
+                .SetupSequence(x => x.GetObjectAsync(
+                    It.Is<GetObjectRequest>(input => input.BucketName == ExpectedBucketName && input.Key == ExpectedS3Key && input.EtagToNotMatch == null || input.EtagToNotMatch == initialEtag),
+                    It.IsAny<CancellationToken>()
+                ))
+                .ReturnsAsync(
+                    new GetObjectResponse()
+                    {
+                        BucketName = ExpectedBucketName,
+                        Key = ExpectedS3Key,
+                        ETag = initialEtag
+                    }
+                )
+                .ThrowsAsync(
+                    new AmazonS3Exception("")
+                    {
+                        ErrorCode = "NotModified",
+                        StatusCode = System.Net.HttpStatusCode.NotModified
+                    }
+                );
+
+            Mock<IS3ObjectParser> parserMock = new Mock<IS3ObjectParser>(MockBehavior.Strict);
+            parserMock
+                .Setup(x => x.ParseAsync(
+                    It.Is<GetObjectResponse>(
+                        input => input.BucketName == ExpectedBucketName && input.Key == ExpectedS3Key && input.ETag == initialEtag
+                    )
+                ))
+                .ReturnsAsync(initialConfiguration)
+                .Verifiable();
+
+            Mock<IReloadTrigger> triggerMock = new Mock<IReloadTrigger>();
+            triggerMock
+                .SetupAdd(x => x.Triggered += It.IsAny<EventHandler>())
+                .Verifiable();
+
+            //act
+            S3ConfigurationProvider provider = new S3ConfigurationProvider(configMock.Object, s3Mock.Object, parserMock.Object, triggerMock.Object);
+
+            int loadTimes = 0;
+
+            void Invoke()
+            {
+                using (ChangeToken.OnChange(provider.GetReloadToken, () => loadTimes++))
+                {
+                    provider.Load();
+                    triggerMock.Raise(x => x.Triggered += null, EventArgs.Empty);
+                }
+            }
+
+            //assert
+            Assert.DoesNotThrow(Invoke);
+            Assert.That(loadTimes, Is.EqualTo(1));
+            configMock.Verify();
+            s3Mock.Verify();
+            parserMock.Verify();
+            triggerMock.Verify();
+        }
+
+        [Description("Tests the provider's behavior on initial load for a non-existing key in the given S3 bucket depending on whether the configuration source is optional or mandatory.")]
+        [Author("Tamás Sinku (sinkutamas@gmail.com)")]
+        [TestCase(false, Description = "The configuration source is mandatory and exception should be thrown.")]
+        [TestCase(true, Description = "The configuration source is optional and exception should not be thrown.")]
+        public void InitialLoadBehaviorWithNonExistingKeyTest(bool optional)
+        {
+            //arrange
+            const string nonExistingKey = "not-existing-key.json";
+
+            Mock<IS3ProviderConfiguration> configMock = new Mock<IS3ProviderConfiguration>(MockBehavior.Strict);
+            configMock
+                .SetupGet(x => x.BucketName)
+                .Returns(ExpectedBucketName)
+                .Verifiable();
+
+            configMock
+                .SetupGet(x => x.Key)
+                .Returns(nonExistingKey)
+                .Verifiable();
+
+            configMock
+                .SetupGet(x => x.Optional)
+                .Returns(optional)
+                .Verifiable();
+
+            Mock<IAmazonS3> s3Mock = new Mock<IAmazonS3>(MockBehavior.Strict);
+            s3Mock
+                .SetupSequence(x => x.GetObjectAsync(
+                    It.Is<GetObjectRequest>(input => input.BucketName == ExpectedBucketName && input.Key == nonExistingKey && input.EtagToNotMatch == null),
+                    It.IsAny<CancellationToken>()
+                ))
+                .ThrowsAsync(
+                    new AmazonS3Exception("")
+                    {
+                        ErrorCode = "NoSuchKey",
+                        StatusCode = System.Net.HttpStatusCode.NotFound
+                    }
+                );
+            
+            //act
+            S3ConfigurationProvider provider = new S3ConfigurationProvider(configMock.Object, s3Mock.Object, null, null);
+            void Invoke() => provider.Load();
+
+            //assert
+            if (optional)
+                Assert.DoesNotThrow(Invoke);
+            else
+                Assert.Throws<AmazonS3Exception>(Invoke);
+
+            configMock.Verify();
+            s3Mock.Verify();
+        }
+    }
+}

--- a/src/MilestoneTG.Extensions.Configuration.S3.sln
+++ b/src/MilestoneTG.Extensions.Configuration.S3.sln
@@ -14,7 +14,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		mySettings.json = mySettings.json
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MilestoneTG.Extensions.Configuration.S3.Yaml", "MilestoneTG.Extensions.Configuration.S3.Yaml\MilestoneTG.Extensions.Configuration.S3.Yaml.csproj", "{8D172F97-EA96-4043-9791-41C24BD1ED94}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MilestoneTG.Extensions.Configuration.S3.Yaml", "MilestoneTG.Extensions.Configuration.S3.Yaml\MilestoneTG.Extensions.Configuration.S3.Yaml.csproj", "{8D172F97-EA96-4043-9791-41C24BD1ED94}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MilestoneTG.Extensions.Configuration.S3.UnitTests", "MilestoneTG.Extensions.Configuration.S3.UnitTests\MilestoneTG.Extensions.Configuration.S3.UnitTests.csproj", "{3B44E973-9E0E-4E38-A755-C2F6B07969BD}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -38,6 +40,10 @@ Global
 		{8D172F97-EA96-4043-9791-41C24BD1ED94}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8D172F97-EA96-4043-9791-41C24BD1ED94}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8D172F97-EA96-4043-9791-41C24BD1ED94}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3B44E973-9E0E-4E38-A755-C2F6B07969BD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3B44E973-9E0E-4E38-A755-C2F6B07969BD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3B44E973-9E0E-4E38-A755-C2F6B07969BD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3B44E973-9E0E-4E38-A755-C2F6B07969BD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/MilestoneTG.Extensions.Configuration.S3/IReloadTrigger.cs
+++ b/src/MilestoneTG.Extensions.Configuration.S3/IReloadTrigger.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace MilestoneTG.Extensions.Configuration.S3
+{
+    /// <summary>
+    /// Represents a trigger that initiates the reloading process.
+    /// </summary>
+    public interface IReloadTrigger
+    {
+        /// <summary>
+        /// This event is fired when the configuration should be polled from S3.
+        /// </summary>
+        event EventHandler Triggered;
+
+        /// <summary>
+        /// Blocks the current thread until <see cref="Triggered"/> is fired.
+        /// </summary>
+        /// <param name="timeout"></param>
+        void BlockThreadUntilTriggered(TimeSpan timeout);
+    }
+}

--- a/src/MilestoneTG.Extensions.Configuration.S3/IS3ProviderConfiguration.cs
+++ b/src/MilestoneTG.Extensions.Configuration.S3/IS3ProviderConfiguration.cs
@@ -1,0 +1,30 @@
+﻿using System;
+
+namespace MilestoneTG.Extensions.Configuration.S3
+{
+    /// <summary>
+    /// Represents the expected configuration for <see cref="S3ConfigurationProvider"/>.
+    /// </summary>
+    public interface IS3ProviderConfiguration
+    {
+        /// <summary>
+        /// Gets the name of the S3 bucket containing the configuration file.
+        /// </summary>
+        string BucketName { get; }
+
+        /// <summary>
+        /// Gets the name of the S3 object in the <see cref="BucketName"/> that represents the configuration file.
+        /// </summary>
+        string Key { get; }
+
+        /// <summary>
+        /// Gets the time interval between two reloads. Null is returned when the configuration does not need to be reloaded.
+        /// </summary>
+        TimeSpan? ReloadAfter { get; }
+
+        /// <summary>
+        /// Gets if loading configuration data from the AWS S3 bucket and Object Key is optional.
+        /// </summary>
+        bool Optional { get; }
+    }
+}

--- a/src/MilestoneTG.Extensions.Configuration.S3/ReloadTrigger.cs
+++ b/src/MilestoneTG.Extensions.Configuration.S3/ReloadTrigger.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.Extensions.Primitives;
+using System;
+using System.Threading;
+
+namespace MilestoneTG.Extensions.Configuration.S3
+{
+    internal class ReloadTrigger : IReloadTrigger
+    {
+        private readonly ManualResetEvent reloadTaskEvent = new ManualResetEvent(true);
+
+        public event EventHandler Triggered;
+
+        public ReloadTrigger(TimeSpan reloadInterval)
+        {
+            SetupReloader(reloadInterval);
+        }
+
+        private void SetupReloader(TimeSpan reloadAfter)
+        {
+            ChangeToken.OnChange(() =>
+            {
+                var cancellationTokenSource = new CancellationTokenSource(reloadAfter);
+                var cancellationChangeToken = new CancellationChangeToken(cancellationTokenSource.Token);
+                return cancellationChangeToken;
+            }, () =>
+            {
+                reloadTaskEvent.Reset();
+                try
+                {
+                    Triggered?.Invoke(this, EventArgs.Empty);
+                }
+                finally
+                {
+                    reloadTaskEvent.Set();
+                }
+            });
+        }
+
+        /// <summary>
+        /// If this configuration provider is currently performing a reload of the config data this method will block until
+        /// the reload is called.
+        /// 
+        /// This method is not meant for general use. It is exposed so a Lambda function can wait for the reload to complete
+        /// before completing the event causing the Lambda compute environment to be frozen.
+        /// </summary>
+        public void BlockThreadUntilTriggered(TimeSpan timeout)
+        {
+            reloadTaskEvent.WaitOne(timeout);
+        }
+    }
+}


### PR DESCRIPTION
In this PR I implemented a feature to resolve the following problem I encountered.
1. The application starts with the configuration successfully loaded from S3. The LoadJsonS3Object is configured to poll the S3 bucket for changes with a given time interval.
2. Someone deletes the configuration file from S3 while the application is running, which will cause AmazonS3Exception, which is handled in the library and not reported towards my application. However, my application needs to know about it, because I wanted to log this error.

To achieve this, I made the following modifications to the code:
- Refactored the code so that I could implement unit tests
- Instead reporting configuration change with each poll, I refactored the code to report change only if a real change has made to the configuration file
- I introduced a new OnException argument to LoadJsonS3Object and LoadYamlS3Object extension methods that I can use to log any exceptions that are thrown during the file download process.
